### PR TITLE
Use arduinoDir instead of explicit path

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 This script sets up the build environment, collects dependencies and provides commands for building and uploading Marlin from the commandline. It uses the official Arduino toolchain. Everything is standalone nothing is installed outside the marlintool directory.
 
-The script is setup by default to build the Marlin fork [“Skynet3D”](https://github.com/SkyNet3D/Marlin) for the Anet A8 Prusa clone but can be easily reconfigured to build any Marlin variant.
-Just change the "marlinRepositoryUrl" parameter at the beginning of the script to the respective github repository.
+The script is setup by default to build the 1.1.x branch of the official Marlin [“Marlin”](https://github.com/MarlinFirmware/Marlin) but can be easily reconfigured to build any Marlin variant.
+Just change the "marlinRepositoryUrl" and "marlinRepositoryBranch" parameters at the beginning of the script to the respective github repository.
 
-Recently Anet A6/A8 support has been merged back into the main Marlin branch. I would highly recommend to switch to the official Marlin branch from now on. You can find example configurations for Anet printers in the Marlin sources at: https://github.com/MarlinFirmware/Marlin/tree/1.1.x/Marlin/example_configurations/Anet. Just replace the "Configuration.h" and "Configuration_adv.h" in the marlin directory with these files for a good starting point for your configuration.
+After downloading Marlin the example configuration files for the Anet A8 are copied in the marlin directory. Just change the "printer" parameter at the beginning of the script to have the appropriate example configuration files for your printer copied instead.
 
 
 Several parameters at the beginning of the script allow to adapt the script further to your needs.

--- a/marlintool.sh
+++ b/marlintool.sh
@@ -6,6 +6,9 @@
 # Official Marlin repository
 marlinRepositoryUrl="https://github.com/MarlinFirmware/Marlin"
 
+# Repository branch to use
+marlinRepositoryBranch="1.1.x"
+
 # Anet board hardware definition repository URL.
 # Set to empty string if you don't need this.
 hardwareDefinitionRepo="https://github.com/SkyNet3D/anet-board.git"
@@ -100,7 +103,7 @@ getMarlin()
 {
    echo -e "\nCloning Marlin \"$marlinRepositoryUrl\" ...\n"
 
-   git clone "$marlinRepositoryUrl" "$marlinDir" 
+   git clone -b "$marlinRepositoryBranch" --single-branch "$marlinRepositoryUrl" "$marlinDir" 
 
    backupMarlinConfiguration "original"
 

--- a/marlintool.sh
+++ b/marlintool.sh
@@ -195,7 +195,7 @@ verifyBuild()
 {
    echo -e "\nVerifying build...\n"
 
-   ./arduino/arduino --verify --verbose --board "$boardString" "$marlinDir"/Marlin/Marlin.ino --pref build.path="$buildDir"
+   "$arduinoDir"/arduino --verify --verbose --board "$boardString" "$marlinDir"/Marlin/Marlin.ino --pref build.path="$buildDir"
    exit
 }
 
@@ -205,7 +205,7 @@ buildAndUpload()
 {
    echo -e "\nBuilding and uploading Marlin build from \"$buildDir\" ...\n"
 
-   ./arduino/arduino --upload --port "$port" --verbose --board "$boardString" "$marlinDir"/Marlin/Marlin.ino --pref build.path="$buildDir"
+   "$arduinoDir"/arduino --upload --port "$port" --verbose --board "$boardString" "$marlinDir"/Marlin/Marlin.ino --pref build.path="$buildDir"
    exit
 }
 

--- a/marlintool.sh
+++ b/marlintool.sh
@@ -3,11 +3,8 @@
 # by mmone with contribution by jhol
 # on github at https://github.com/mmone/marlintool
 
-# Marlin fork optimized for the AnetA8 Prusa clone
-marlinRepositoryUrl="https://github.com/SkyNet3D/Marlin"
-
-# Original Marlin
-# marlinRepositoryUrl="https://github.com/MarlinFirmware/Marlin"
+# Official Marlin repository
+marlinRepositoryUrl="https://github.com/MarlinFirmware/Marlin"
 
 # Anet board hardware definition repository URL.
 # Set to empty string if you don't need this.

--- a/marlintool.sh
+++ b/marlintool.sh
@@ -69,7 +69,7 @@ getArduinoToolchain()
    echo -e "\nDownloading Arduino environment ...\n"
    wget http://downloads-02.arduino.cc/arduino-"$arduinoToolchainVersion"-"$arduinoToolchainArchitecture".tar.xz
    mkdir "$arduinoDir"
-   echo -e "\nUnpacking Arduino environment. This might take a while ... "
+   echo -e "\nUnpacking Arduino environment. This might take a while ...\n"
    tar -xf arduino-"$arduinoToolchainVersion"-"$arduinoToolchainArchitecture".tar.xz -C "$arduinoDir" --strip 1
    rm -R arduino-"$arduinoToolchainVersion"-"$arduinoToolchainArchitecture".tar.xz
 }
@@ -98,13 +98,13 @@ getDependencies()
 ## Clone Marlin
 getMarlin()
 {
-   echo -e "\nCloning Marlin \"$marlinRepositoryUrl\"...\n"
+   echo -e "\nCloning Marlin \"$marlinRepositoryUrl\" ...\n"
 
    git clone "$marlinRepositoryUrl" "$marlinDir" 
 
    backupMarlinConfiguration "original"
 
-   echo -e "\nCopying Anet $printer example configuration files to \"$marlinDir/Marlin\"...\n"
+   echo -e "\nCopying Anet $printer example configuration files to \"./$marlinDir/Marlin\" ...\n"
    cp "$marlinDir"/Marlin/example_configurations/Anet/"$printer"/Configuration.h "$marlinDir"/Marlin/Configuration.h
    cp "$marlinDir"/Marlin/example_configurations/Anet/"$printer"/Configuration_adv.h "$marlinDir"/Marlin/Configuration_adv.h
    exit
@@ -120,7 +120,7 @@ checkoutMarlin()
 
    cd $marlinDir
 
-   echo -e "\nFetching most recent Marlin from \"$marlinRepositoryUrl\"..\n"
+   echo -e "\nFetching most recent Marlin from \"$marlinRepositoryUrl\" ...\n"
 
    git fetch
    git checkout
@@ -150,10 +150,10 @@ getHardwareDefinition()
 {
    if [ "$hardwareDefinitionRepo" != "" ]; then
    
-   echo -e "\nCloning board hardware definition from:\n $hardwareDefinitionRepo \n"
+   echo -e "\nCloning board hardware definition from \"$hardwareDefinitionRepo\" ...\n"
    git clone "$hardwareDefinitionRepo"
 
-   echo -e "\nMoving board hardware definition into arduino directory... \n"
+   echo -e "\nMoving board hardware definition into arduino directory ...\n"
    
    repoName=$(basename "$hardwareDefinitionRepo" ".${hardwareDefinitionRepo##*.}")
    
@@ -199,7 +199,7 @@ restoreMarlinConfiguration()
 ## Build Marlin
 verifyBuild()
 {
-   echo -e "\nVerifying build...\n"
+   echo -e "\nVerifying build ...\n"
 
    "$arduinoDir"/arduino --verify --verbose --board "$boardString" "$marlinDir"/Marlin/Marlin.ino --pref build.path="$buildDir"
    exit

--- a/marlintool.sh
+++ b/marlintool.sh
@@ -13,6 +13,9 @@ hardwareDefinitionRepo="https://github.com/SkyNet3D/anet-board.git"
 # Anet board identifier.
 boardString="anet:avr:anet"
 
+# Anet printer model
+printer="A8"
+
 # Arduino Mega
 # boardString="arduino:avr:mega:cpu=atmega2560"
 
@@ -98,6 +101,12 @@ getMarlin()
    echo -e "\nCloning Marlin \"$marlinRepositoryUrl\"...\n"
 
    git clone "$marlinRepositoryUrl" "$marlinDir" 
+
+   backupMarlinConfiguration "original"
+
+   echo -e "\nCopying Anet $printer example configuration files to \"$marlinDir/Marlin\"...\n"
+   cp "$marlinDir"/Marlin/example_configurations/Anet/"$printer"/Configuration.h "$marlinDir"/Marlin/Configuration.h
+   cp "$marlinDir"/Marlin/example_configurations/Anet/"$printer"/Configuration_adv.h "$marlinDir"/Marlin/Configuration_adv.h
    exit
 }
 


### PR DESCRIPTION
When building to upload or to verify `arduino` was being called explicitly at ./arduino/arduino instead of using the arduinoDir variable.