### PR TITLE
Add support for OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Several parameters at the beginning of the script allow to adapt the script furt
 
 - If you need additional libraries for your build add them to the "getDependencies" function.
 
-- The build platform architecture is auto detected. At the moment Linux 32 Bit, 64 Bit and ARM are supported.
+- The build platform and architecture are auto detected. At the moment Linux 32 Bit, 64 Bit, ARM and OS X are supported.
 
 Reminder: If you are running octopi on you Raspberry you need to disconnect it from your printer before uploading, otherwise the serial port is blocked.
 
-
+Warning: On OS X due to how the Arduino toolchain is packaged the Arduino splash screen will be displayed even when the toolchain is used from the commandline. This will cause the terminal window you launch marlintool from to lose focus. It also means that a build cannot be launched from a remote ssh session.
 
 Available commandline parameters
 =======================

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Several parameters at the beginning of the script allow to adapt the script furt
 
 Reminder: If you are running octopi on you Raspberry you need to disconnect it from your printer before uploading, otherwise the serial port is blocked.
 
-Warning: On OS X due to how the Arduino toolchain is packaged the Arduino splash screen will be displayed even when the toolchain is used from the commandline. This will cause the terminal window you launch marlintool from to lose focus. It also means that a build cannot be launched from a remote ssh session.
+*Note: On OS X due to how the Arduino toolchain is packaged the Arduino splash screen will be displayed even when the toolchain is used from the commandline. This will cause the terminal window you launch marlintool from to lose focus. It also means that a build cannot be launched from a remote ssh session.*
 
 Available commandline parameters
 =======================


### PR DESCRIPTION
This PR adds support for OS X. You will notice that for OS X the script is using curl instead of wget to fetch the Arduino toolchain. The standard OS X OS installation includes curl but not wget. All tool requirement on OS X are met by the standard OS install.

You will also notice a warning regarding OS X in the Readme. The Arduino toolchain for OS X is packaged using launch4j. When you call the Arduino app you are actually calling a launch4j launcher which in turn executes the arduino software.  The launcher will always display the arduino splash screen. There is no means to disable it. This has 2 impacts. The first is that when launching a build focus will switch from the active terminal window to the splash screen. The user will have to manually switch focus back to the terminal windows. The second is that calling the arduino commandline from a remote ssh session will fail since the splash screen can't be displayed.