### PR TITLE
Fix Arduino leaking outside $arduinoDir on Linux

### DIFF
--- a/marlintool.sh
+++ b/marlintool.sh
@@ -88,7 +88,7 @@ getArduinoToolchain()
    else
      wget http://downloads-02.arduino.cc/"$arduinoToolchainArchive"
    fi
-   mkdir "$arduinoDir"
+   mkdir -p "$arduinoDir/portable"
    echo -e "\nUnpacking Arduino environment. This might take a while ...\n"
    if [ "$os" == "Darwin" ]; then
      unzip -q "$arduinoToolchainArchive" -d "$arduinoDir"


### PR DESCRIPTION
If they do not already exist the Arduino application will create 2 directories in a user's home directory whenever it is run. On linux ~/.arduino15 and ~/Arduino. On OS X ~/Library/Ardunio15 and ~/Documents/Ardunio. On OS X there is not a way to prevent the application from doing so, but on linux if a directory named portable is created in the same directory as the ardunio executable it will not create the directories.